### PR TITLE
 Fix iOS duplicate remote-command handlers and add Android cover-art cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 .idea/
+*.iml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="@andeo/cordova-plugin-music-controls2"
-	version="1.0.0">
+	version="1.0.9">
 	<name>Music Controls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/andeodev/cordova-plugin-music-controls2</repo>

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -56,6 +56,11 @@ public class MusicControls extends CordovaPlugin {
 	private boolean mediaButtonAccess=true;
 	private android.media.session.MediaSession.Token token;
 
+	// Cover-art cache: avoids re-downloading the same image on every create() call
+	// (e.g. the 300 ms Android retry and seek-triggered updates all use the same URL).
+	private String cachedCoverUrl = null;
+	private Bitmap cachedCoverBitmap = null;
+
   	private Activity cordovaActivity;
 
 	private MediaSessionCallback mMediaSessionCallback = new MediaSessionCallback();
@@ -307,16 +312,25 @@ public class MusicControls extends CordovaPlugin {
         }
 	}
 
-	// Get image from url
+	// Get image from url, with a single-entry cache keyed on the URL.
 	private Bitmap getBitmapCover(String coverURL){
+		if (coverURL == null || coverURL.isEmpty()) {
+			cachedCoverUrl = null;
+			cachedCoverBitmap = null;
+			return null;
+		}
+		if (coverURL.equals(cachedCoverUrl) && cachedCoverBitmap != null) {
+			return cachedCoverBitmap;
+		}
 		try{
+			Bitmap bitmap;
 			if(coverURL.matches("^(https?|ftp)://.*$"))
-				// Remote image
-				return getBitmapFromURL(coverURL);
-			else {
-				// Local image
-				return getBitmapFromLocal(coverURL);
-			}
+				bitmap = getBitmapFromURL(coverURL);
+			else
+				bitmap = getBitmapFromLocal(coverURL);
+			cachedCoverUrl = coverURL;
+			cachedCoverBitmap = bitmap;
+			return bitmap;
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			return null;

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -51,6 +51,11 @@ MusicControlsInfo * musicControlsSettings;
         nowPlayingInfoCenter.nowPlayingInfo = updatedNowPlayingInfo;
     }];
 
+    // Deregister before re-registering to prevent duplicate MPRemoteCommandCenter handlers.
+    // Without this, every create() call stacks another handler set on top of the previous
+    // ones; after minutes of periodic calls those duplicates fire simultaneously on each
+    // lock-screen / Bluetooth button press, crashing or corrupting playback state.
+    [self deregisterMusicControlsEventListener];
     [self registerMusicControlsEventListener];
 }
 
@@ -315,9 +320,11 @@ MusicControlsInfo * musicControlsSettings;
 
 - (void) deregisterMusicControlsEventListener {
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"receivedEvent" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"musicControlsEventNotification" object:nil];
 
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+    [commandCenter.playCommand removeTarget:self];
+    [commandCenter.pauseCommand removeTarget:self];
     [commandCenter.nextTrackCommand removeTarget:self];
     [commandCenter.previousTrackCommand removeTarget:self];
 


### PR DESCRIPTION
## Problem

Two bugs introduced with the `elapsed`/`duration` support in 1.0.8 caused
playback crashes and severe slowdowns reported by users after the last release.

### iOS — duplicate MPRemoteCommandCenter handlers

`create()` calls `registerMusicControlsEventListener` on every invocation, but
`deregisterMusicControlsEventListener` had two bugs that made cleanup a no-op:

1. `removeObserver:self name:@"receivedEvent"` — wrong name; the observer was
   registered as `@"musicControlsEventNotification"`, so it was never removed.
2. `playCommand` and `pauseCommand` targets were added in `register` but never
   removed in `deregister`.

After several minutes of playback (create() is called at each track start,
play/pause, and seek), hundreds of duplicate handlers accumulated. A single
Bluetooth or lock-screen button press then fired all of them simultaneously,
sending a cascade of duplicate events to JS and corrupting or crashing playback.

**Symptom:** App froze when skipping tracks or pressing play/pause via
Bluetooth; required force-close and 3–5 minute wait to recover.

### Android — cover art re-downloaded on every create() call

`getBitmapCover()` issued a new HTTP request on every call with no caching.
With periodic `create()` calls from the app layer, this saturated the Cordova
thread pool with image downloads, blocking all subsequent native bridge calls
(audio playback, API requests, login).

**Symptom:** App became unresponsive after minutes of background playback;
required ~30 minutes to recover as the thread pool drained.

## Changes

**`src/ios/MusicControls.m`**
- Call `[self deregisterMusicControlsEventListener]` before
  `[self registerMusicControlsEventListener]` in `create()` so handlers are
  always torn down before being re-added.
- Fix notification name in `deregisterMusicControlsEventListener`:
  `@"receivedEvent"` → `@"musicControlsEventNotification"`.
- Add `[commandCenter.playCommand removeTarget:self]` and
  `[commandCenter.pauseCommand removeTarget:self]` to
  `deregisterMusicControlsEventListener` — these were the only two commands
  registered but never removed.

**`src/android/MusicControls.java`**
- Add a single-entry URL-keyed cache in `getBitmapCover()`. Repeated `create()`
  calls with the same cover URL (retries, seeks, play/pause) now return the
  cached bitmap without an HTTP round-trip.

## Testing

- iOS: play a track for 10+ minutes in the background, then press next/pause via
  Bluetooth — should advance/pause cleanly without freeze.
- Android: play several tracks back to back in the background; the app should
  remain responsive and not require a long recovery period.