### PR TITLE
Fix Android foreground service registration and behavior

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<service android:name="com.homerours.musiccontrols.MusicControlsNotificationKiller" android:stopWithTask="true" android:foregroundServiceType="mediaPlayback"></service>
+			<service android:name="com.homerours.musiccontrols.MusicControlsNotificationKiller" android:stopWithTask="false" android:foregroundServiceType="mediaPlayback"></service>
 		</config-file>
 
 		<framework src="com.android.support:support-v4:28.0.0" />

--- a/src/android/MusicControlsNotificationKiller.java
+++ b/src/android/MusicControlsNotificationKiller.java
@@ -2,6 +2,7 @@ package com.homerours.musiccontrols;
 
 import android.app.Notification;
 import android.app.Service;
+import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -47,9 +48,13 @@ public class MusicControlsNotificationKiller extends Service {
 		LOG.d(LOG_TAG, "Service destroyed");
 	}
 
-	public void setForeground(Notification notification) {
+	public void setForeground(Notification notification, boolean isPlaying) {
 		try {
-		    this.startForeground(this.NOTIFICATION_ID, notification);
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+				this.startForeground(this.NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+			} else {
+				this.startForeground(this.NOTIFICATION_ID, notification);
+			}
         } catch (Exception ex) {
             ex.printStackTrace();
             return;
@@ -60,11 +65,17 @@ public class MusicControlsNotificationKiller extends Service {
 			this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Adonia::MediaPlayer");
 		}
 
-		if (!this.wakeLock.isHeld()) {
+		if (isPlaying && !this.wakeLock.isHeld()) {
 			this.wakeLock.acquire();
+		} else if (!isPlaying && this.wakeLock.isHeld()) {
+			try {
+				this.wakeLock.release();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+			}
 		}
 
-		LOG.d(LOG_TAG, "Service set to foreground");
+		LOG.d(LOG_TAG, "Service set to foreground, isPlaying=" + isPlaying);
 	}
 
 	public void clearForeground() {

--- a/src/android/MusicControlsServiceConnection.java
+++ b/src/android/MusicControlsServiceConnection.java
@@ -33,8 +33,8 @@ public class MusicControlsServiceConnection implements ServiceConnection {
             return;
         }
 
-        if (isPlaying) {
-            this.service.setForeground(notification);
+        if (notification != null) {
+            this.service.setForeground(notification, isPlaying);
         } else {
             this.service.clearForeground();
         }


### PR DESCRIPTION
Fix Android background audio stopping arbitrarily

Addresses three independent bugs that together caused the foreground service to be killed during background playback, stopping audio after an unpredictable number of minutes.

1. Keep foreground service alive while paused (MusicControlsServiceConnection.java)

Previously, setNotification() only called setForeground() when isPlaying=true, and called clearForeground() when paused. Demoting the service from foreground on pause allows Android to kill the process under memory pressure at any time. The service now stays in foreground as long as a notification exists, matching the behaviour of Spotify, Google Podcasts, and every other media app. clearForeground() is reserved for explicit destruction only.

2. API 34+ foreground service type (MusicControlsNotificationKiller.java)

Android 14 (API 34) requires a third argument to startForeground() declaring the service type, or the call throws ForegroundServiceStartNotAllowedException. The fix adds an API level check and passes ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK on API 34+.

The isPlaying parameter added to setForeground() also enables correct wake lock management: PARTIAL_WAKE_LOCK is acquired when playing and released when paused, keeping the CPU alive during playback without preventing it from sleeping during pause.

3. stopWithTask="false" (plugin.xml)

stopWithTask="true" stops the service immediately when the task is removed from Recents. On stock Android this requires a deliberate swipe, but on Samsung, Xiaomi, OPPO, and other OEM devices the battery optimizer removes tasks from Recents automatically after a period of background inactivity which maps directly to the "arbitrary minutes" failure pattern. Changed to false to match standard media app behaviour.