### PR TITLE
Fix media button one-shot callback and add WebView crash recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="@andeo/cordova-plugin-music-controls2"
-	version="1.0.12">
+	version="1.0.13">
 	<name>Music Controls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/andeodev/cordova-plugin-music-controls2</repo>

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -38,6 +38,8 @@ import android.content.BroadcastReceiver;
 import android.media.AudioManager;
 import android.provider.Settings;
 import android.view.View;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebView;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -60,6 +62,10 @@ public class MusicControls extends CordovaPlugin {
 	// (e.g. the 300 ms Android retry and seek-triggered updates all use the same URL).
 	private String cachedCoverUrl = null;
 	private Bitmap cachedCoverBitmap = null;
+
+	// WebView crash recovery: survives renderer death because this plugin runs in the main app process.
+	private long webviewKilledAt = 0;
+	private String storedPlaybackState = null;
 
   	private Activity cordovaActivity;
 
@@ -268,6 +274,38 @@ public class MusicControls extends CordovaPlugin {
 			else
 				callbackContext.success("disabled");
 		}
+		else if (action.equals("storePlaybackState")) {
+			try {
+				JSONObject payload = args.getJSONObject(0);
+				this.storedPlaybackState = payload.toString();
+				callbackContext.success("ok");
+			} catch (JSONException e) {
+				callbackContext.error("Invalid payload");
+			}
+		}
+		else if (action.equals("getRecoveryData")) {
+			if (this.webviewKilledAt == 0 || this.storedPlaybackState == null) {
+				callbackContext.success("null");
+				return true;
+			}
+			try {
+				JSONObject result = new JSONObject(this.storedPlaybackState);
+				result.put("killedAt", this.webviewKilledAt);
+				this.webviewKilledAt = 0;
+				callbackContext.success(result.toString());
+			} catch (JSONException e) {
+				this.webviewKilledAt = 0;
+				callbackContext.success("null");
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+		this.webviewKilledAt = System.currentTimeMillis();
+		LOG.w("MusicControls", "WebView renderer gone (crashed=" + detail.didCrash() + "), reloading");
+		cordova.getActivity().runOnUiThread(() -> view.reload());
 		return true;
 	}
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -142,4 +142,11 @@ declare var MusicControls: {
      * Check if battery optimizations are enabled.
      */
     checkBatteryOptimizations(callback: (status: MediaControls.BatteryOptimizationStatus) => void): void;
+
+    /** Store current playback state in native memory for WebView crash recovery. Android only. */
+    storePlaybackState(data: object, onSuccess: () => void, onError: () => void): void;
+
+    /** Retrieve stored crash-recovery data. Returns null JSON string if no crash occurred. Android only. */
+    getRecoveryData(onSuccess: (data: string) => void, onError: () => void): void;
+
 };

--- a/www/MusicControls.js
+++ b/www/MusicControls.js
@@ -90,6 +90,11 @@ var musicControls = {
   },
   receiveCallbackFromNative: function(messageFromNative) {
     musicControls.updateCallback(messageFromNative);
+    // Re-arm the native watch for the next button press.
+    // The Java callbacks (MediaSessionCallback, BroadcastReceiver) null themselves after
+    // each event and callbackContext.success() sends keepCallback=false, so the Cordova
+    // bridge removes the JS handler after it fires. Re-calling listen() here restores it.
+    musicControls.listen();
   },
 
   disableBatteryOptimizations: function() {
@@ -121,6 +126,27 @@ var musicControls = {
         []
     );
   },
+
+  storePlaybackState: function(data, successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "MusicControls",
+        "storePlaybackState",
+        [data]
+    );
+  },
+
+  getRecoveryData: function(successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "MusicControls",
+        "getRecoveryData",
+        []
+    );
+  },
+
 };
 
 function isUndefined(val) {


### PR DESCRIPTION
- Re-arm listen() in receiveCallbackFromNative so lock screen/Bluetooth
  buttons keep working after the first press (keepCallback=false consumed
  the JS handler after one fire)
- Add storePlaybackState action: stores current+next track URL in native
  memory so JS state survives a WebView renderer crash
- Add getRecoveryData action: returns stored state + timestamp if a crash
  occurred, clears flag on read
- Handle onRenderProcessGone to detect renderer death and trigger reload
- Add TypeScript declarations for new plugin APIs
- Bump version to 1.0.13